### PR TITLE
Aps 3 reusable list view

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -23,6 +23,7 @@
     "react-router-to-array": "^0.1.3",
     "react-scripts": "5.0.1",
     "react-select": "^5.7.0",
+    "react-table": "^7.8.0",
     "tailwindcss": "^3.2.7",
     "web-vitals": "^2.1.4",
     "zustand": "^4.1.4"

--- a/frontend/src/components/Admin/Table/Table.js
+++ b/frontend/src/components/Admin/Table/Table.js
@@ -81,7 +81,7 @@ const Table = ({ columns, data }) => {
           <input
             value={searchInput}
             onChange={handleSearchChange}
-            placeholder={"Search name"}
+            placeholder="Search name"
             className="admin-tables"
           />
           <select

--- a/frontend/src/components/Admin/Table/Table.js
+++ b/frontend/src/components/Admin/Table/Table.js
@@ -8,14 +8,15 @@ import {
   faArrowDownZA,
   faArrowRotateRight
 } from "@fortawesome/free-solid-svg-icons";
+import { useNavigate } from "react-router-dom"
 
-const Table = ({ columns, data }) => {
+const Table = ({ columns, data, path }) => {
   const right = <FontAwesomeIcon icon={faAnglesRight} />;
   const left = <FontAwesomeIcon icon={faAnglesLeft} />;
   const asc = <FontAwesomeIcon icon={faArrowUpAZ} />;
   const desc = <FontAwesomeIcon icon={faArrowDownZA} />;
   const reset = <FontAwesomeIcon icon={faArrowRotateRight} />;
-
+  const navigate = useNavigate()
   const {
     getTableProps,
     getTableBodyProps,
@@ -67,6 +68,10 @@ const Table = ({ columns, data }) => {
   const handleReset = () => {
     setSearchInput("")
     setAllFilters([])
+  }
+
+  const handleLink = (id) => {
+    navigate(id)
   }
 
   return (
@@ -192,7 +197,7 @@ const Table = ({ columns, data }) => {
               <tr {...row.getRowProps()}>
                 {row.cells.map((cell) => {
                   return (
-                    <td className="admin-tables" {...cell.getCellProps()}>
+                    <td className="admin-tables cursor-pointer" {...cell.getCellProps()} onClick={() => handleLink(row.values.id)}>
                       {cell.render("Cell")}
                     </td>
                   );

--- a/frontend/src/components/Admin/Table/Table.js
+++ b/frontend/src/components/Admin/Table/Table.js
@@ -1,11 +1,20 @@
 import { useTable, useFilters, useSortBy, usePagination } from "react-table";
 import { useState } from "react";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
-import { faAnglesRight, faAnglesLeft } from "@fortawesome/free-solid-svg-icons";
+import { 
+  faAnglesRight,
+  faAnglesLeft,
+  faArrowUpAZ,
+  faArrowDownZA,
+  faArrowRotateRight
+} from "@fortawesome/free-solid-svg-icons";
 
 const Table = ({ columns, data }) => {
   const right = <FontAwesomeIcon icon={faAnglesRight} />;
   const left = <FontAwesomeIcon icon={faAnglesLeft} />;
+  const asc = <FontAwesomeIcon icon={faArrowUpAZ} />;
+  const desc = <FontAwesomeIcon icon={faArrowDownZA} />;
+  const reset = <FontAwesomeIcon icon={faArrowRotateRight} />;
 
   const {
     getTableProps,
@@ -23,11 +32,12 @@ const Table = ({ columns, data }) => {
     pageCount,
     setPageSize,
     prepareRow,
+    setAllFilters,
   } = useTable(
     {
       columns,
       data,
-      initialState: { pageIndex: 0 },
+      initialState: { pageIndex: 0, pageSize: 25 },
     },
     useFilters,
     useSortBy,
@@ -49,16 +59,16 @@ const Table = ({ columns, data }) => {
   };
 
   const getSearchChoices = () => {
-    if (!data) return [];
+    if (!data || columns.length === 0) return [];
 
-    return Object.keys(data[0]);
+    return columns[0].columns
   };
 
-  const normalizeText = (text) => {
-    const addedSpace = text.replace(/([A-Z])/g, " $1");
-    return addedSpace.charAt(0).toUpperCase() + addedSpace.slice(1);
-  };
-  console.log(columns[0]);
+  const handleReset = () => {
+    setSearchInput("")
+    setAllFilters([])
+  }
+
   return (
     <div className="m-2">
       <div className="flex flex-row justify-between">
@@ -76,12 +86,13 @@ const Table = ({ columns, data }) => {
           >
             {getSearchChoices().map((e, index) => {
               return (
-                <option key={index} value={e}>
-                  {normalizeText(e)}
+                <option key={index} value={e.accessor}>
+                  {e.Header}
                 </option>
               );
             })}
           </select>
+          <span onClick={handleReset} className="pl-3 hover:cursor-pointer select-none">{reset} Reset</span>
         </div>
 
         <div>
@@ -90,7 +101,7 @@ const Table = ({ columns, data }) => {
             onChange={(e) => setPageSize(Number(e.target.value))}
             className="admin-tables"
           >
-            {[10, 25, 50].map((pageSize) => (
+            {[25, 50, 100].map((pageSize) => (
               <option key={pageSize} value={pageSize}>
                 Show {pageSize}
               </option>
@@ -156,15 +167,16 @@ const Table = ({ columns, data }) => {
               {headerGroup.headers.map((column) => (
                 <th
                   {...column.getHeaderProps(column.getSortByToggleProps())}
-                  className={
+                  className="admin-tables select-none"
+                >
+                  {column.render("Header")} {" "}
+                  {
                     column.isSorted
                       ? column.isSortedDesc
-                        ? "admin-tables after:content-['⬇️']"
-                        : "admin-tables after:content-['⬆️']"
-                      : "admin-tables"
+                        ? desc
+                        : asc
+                      : ""
                   }
-                >
-                  {column.render("Header")}
                 </th>
               ))}
             </tr>

--- a/frontend/src/components/Admin/Table/Table.js
+++ b/frontend/src/components/Admin/Table/Table.js
@@ -10,7 +10,7 @@ import {
 } from "@fortawesome/free-solid-svg-icons";
 import { useNavigate } from "react-router-dom"
 
-const Table = ({ columns, data, path }) => {
+const Table = ({ columns, data }) => {
   const right = <FontAwesomeIcon icon={faAnglesRight} />;
   const left = <FontAwesomeIcon icon={faAnglesLeft} />;
   const asc = <FontAwesomeIcon icon={faArrowUpAZ} />;

--- a/frontend/src/components/Admin/Table/Table.js
+++ b/frontend/src/components/Admin/Table/Table.js
@@ -1,64 +1,155 @@
-import { useTable, useFilters, useSortBy } from "react-table"
-import { useState } from "react"
+import { useTable, useFilters, useSortBy, usePagination } from "react-table";
+import { useState } from "react";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import { faAnglesRight, faAnglesLeft } from "@fortawesome/free-solid-svg-icons";
 
 const Table = ({ columns, data }) => {
+  const right = <FontAwesomeIcon icon={faAnglesRight} />;
+  const left = <FontAwesomeIcon icon={faAnglesLeft} />;
+
   const {
     getTableProps,
     getTableBodyProps,
     headerGroups,
-    rows,
-    prepareRow,
+    page,
+    nextPage,
+    previousPage,
+    canPreviousPage,
+    canNextPage,
+    pageOptions,
     setFilter,
+    state,
+    gotoPage,
+    pageCount,
+    setPageSize,
+    prepareRow,
   } = useTable(
     {
       columns,
       data,
+      initialState: { pageIndex: 0 },
     },
     useFilters,
-    useSortBy
+    useSortBy,
+    usePagination
   );
-  const [searchInput, setSearchInput] = useState("")
-  const [filterInput, setFilterInput] = useState("id")
+  const [searchInput, setSearchInput] = useState("");
+  const [filterInput, setFilterInput] = useState("id");
+  const { pageIndex, pageSize } = state;
 
   const handleSearchChange = (e) => {
-    const value = e.target.value || ""
-    setFilter(filterInput, value)
-    setSearchInput(value)
+    const value = e.target.value || "";
+    setFilter(filterInput, value);
+    setSearchInput(value);
   };
 
   const handleFilterChange = (e) => {
-    const value = e.target.value || ""
-    setFilterInput(value)
-  }
+    const value = e.target.value || "";
+    setFilterInput(value);
+  };
 
   const getSearchChoices = () => {
-    if(!data) return []
+    if (!data) return [];
 
-    return Object.keys(data[0])
-  }
+    return Object.keys(data[0]);
+  };
 
   const normalizeText = (text) => {
-    const addedSpace = text.replace(/([A-Z])/g, " $1")
-    return addedSpace.charAt(0).toUpperCase() + addedSpace.slice(1)
-  }
-  console.log(columns)
+    const addedSpace = text.replace(/([A-Z])/g, " $1");
+    return addedSpace.charAt(0).toUpperCase() + addedSpace.slice(1);
+  };
+  console.log(columns[0]);
   return (
-    <>
-      <div className="m-2">
-        <input
-          value={searchInput}
-          onChange={handleSearchChange}
-          placeholder={"Search name"}
-          className="admin-tables"
-        />
-        <select name="filter" className="admin-tables" onChange={handleFilterChange}>
-          {getSearchChoices().map((e, index)=> {
-            return <option key={index} value={e}>{normalizeText(e)}</option>
-          })}
-        </select>
+    <div className="m-2">
+      <div className="flex flex-row justify-between">
+        <div>
+          <input
+            value={searchInput}
+            onChange={handleSearchChange}
+            placeholder={"Search name"}
+            className="admin-tables"
+          />
+          <select
+            name="filter"
+            className="admin-tables"
+            onChange={handleFilterChange}
+          >
+            {getSearchChoices().map((e, index) => {
+              return (
+                <option key={index} value={e}>
+                  {normalizeText(e)}
+                </option>
+              );
+            })}
+          </select>
+        </div>
+
+        <div>
+          <select
+            value={pageSize}
+            onChange={(e) => setPageSize(Number(e.target.value))}
+            className="admin-tables"
+          >
+            {[10, 25, 50].map((pageSize) => (
+              <option key={pageSize} value={pageSize}>
+                Show {pageSize}
+              </option>
+            ))}
+          </select>
+        </div>
       </div>
 
-      <table className="admin-tables m-2" {...getTableProps()}>
+      <div>
+        <button
+          onClick={() => gotoPage(0)}
+          disabled={!canPreviousPage}
+          className={"mr-2 " + (!canPreviousPage ? "text-gray-400" : "text-admin_primary")}
+        >
+          {left}
+        </button>
+        <button
+          onClick={() => previousPage()}
+          disabled={!canPreviousPage}
+          className={!canPreviousPage ? "text-gray-400" : "text-admin_primary"}
+        >
+          Previous
+        </button>
+        <span className="ml-3 mr-3">
+          <strong>
+            {pageIndex + 1} of {pageOptions.length}
+          </strong>
+        </span>
+        <button
+          onClick={() => nextPage()}
+          disabled={!canNextPage}
+          className={!canNextPage ? "text-gray-400" : "text-admin_primary"}
+        >
+          Next
+        </button>
+        <button
+          onClick={() => gotoPage(pageCount - 1)}
+          disabled={!canNextPage}
+          className={"ml-2 " + (!canNextPage ? "text-gray-400" : "text-admin_primary")}
+        >
+          {right}
+        </button>
+        <span className="ml-4">
+          Go to page:
+          <input
+            type="number"
+            defaultValue={pageIndex + 1}
+            onChange={(e) => {
+              const pageNumber = e.target.value
+                ? Number(e.target.value) - 1
+                : 0;
+              gotoPage(pageNumber);
+            }}
+            className="admin-tables w-11"
+          />
+        </span>
+      </div>
+
+      <table className="admin-tables" {...getTableProps()}>
         <thead>
           {headerGroups.map((headerGroup) => (
             <tr className="admin-tables" {...headerGroup.getHeaderGroupProps()}>
@@ -83,22 +174,24 @@ const Table = ({ columns, data }) => {
           {...getTableBodyProps()}
           className="[&>*:nth-child(odd)]:bg-gray-50 [&>*:nth-child(even)]:bg-admin_bg"
         >
-          {rows.map((row) => {
-            prepareRow(row)
+          {page.map((row) => {
+            prepareRow(row);
             return (
               <tr {...row.getRowProps()}>
                 {row.cells.map((cell) => {
                   return (
-                    <td className="admin-tables" {...cell.getCellProps()}>{cell.render("Cell")}</td>
-                  )
+                    <td className="admin-tables" {...cell.getCellProps()}>
+                      {cell.render("Cell")}
+                    </td>
+                  );
                 })}
               </tr>
-            )
+            );
           })}
         </tbody>
       </table>
-    </>
-  )
-}
+    </div>
+  );
+};
 
-export default Table
+export default Table;

--- a/frontend/src/components/Admin/Table/Table.js
+++ b/frontend/src/components/Admin/Table/Table.js
@@ -1,0 +1,104 @@
+import { useTable, useFilters, useSortBy } from "react-table"
+import { useState } from "react"
+
+const Table = ({ columns, data }) => {
+  const {
+    getTableProps,
+    getTableBodyProps,
+    headerGroups,
+    rows,
+    prepareRow,
+    setFilter,
+  } = useTable(
+    {
+      columns,
+      data,
+    },
+    useFilters,
+    useSortBy
+  );
+  const [searchInput, setSearchInput] = useState("")
+  const [filterInput, setFilterInput] = useState("id")
+
+  const handleSearchChange = (e) => {
+    const value = e.target.value || ""
+    setFilter(filterInput, value)
+    setSearchInput(value)
+  };
+
+  const handleFilterChange = (e) => {
+    const value = e.target.value || ""
+    setFilterInput(value)
+  }
+
+  const getSearchChoices = () => {
+    if(!data) return []
+
+    return Object.keys(data[0])
+  }
+
+  const normalizeText = (text) => {
+    const addedSpace = text.replace(/([A-Z])/g, " $1")
+    return addedSpace.charAt(0).toUpperCase() + addedSpace.slice(1)
+  }
+  console.log(columns)
+  return (
+    <>
+      <div className="m-2">
+        <input
+          value={searchInput}
+          onChange={handleSearchChange}
+          placeholder={"Search name"}
+          className="admin-tables"
+        />
+        <select name="filter" className="admin-tables" onChange={handleFilterChange}>
+          {getSearchChoices().map((e, index)=> {
+            return <option key={index} value={e}>{normalizeText(e)}</option>
+          })}
+        </select>
+      </div>
+
+      <table className="admin-tables m-2" {...getTableProps()}>
+        <thead>
+          {headerGroups.map((headerGroup) => (
+            <tr className="admin-tables" {...headerGroup.getHeaderGroupProps()}>
+              {headerGroup.headers.map((column) => (
+                <th
+                  {...column.getHeaderProps(column.getSortByToggleProps())}
+                  className={
+                    column.isSorted
+                      ? column.isSortedDesc
+                        ? "admin-tables after:content-['⬇️']"
+                        : "admin-tables after:content-['⬆️']"
+                      : "admin-tables"
+                  }
+                >
+                  {column.render("Header")}
+                </th>
+              ))}
+            </tr>
+          ))}
+        </thead>
+        <tbody
+          {...getTableBodyProps()}
+          className="[&>*:nth-child(odd)]:bg-gray-50 [&>*:nth-child(even)]:bg-admin_bg"
+        >
+          {rows.map((row) => {
+            prepareRow(row)
+            return (
+              <tr {...row.getRowProps()}>
+                {row.cells.map((cell) => {
+                  return (
+                    <td className="admin-tables" {...cell.getCellProps()}>{cell.render("Cell")}</td>
+                  )
+                })}
+              </tr>
+            )
+          })}
+        </tbody>
+      </table>
+    </>
+  )
+}
+
+export default Table

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -1,3 +1,10 @@
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
+
+@layer components {
+
+  .admin-tables {
+    @apply border-2 border-gray-200
+  }
+}

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -7849,6 +7849,11 @@ react-select@^5.7.0:
     react-transition-group "^4.3.0"
     use-isomorphic-layout-effect "^1.1.2"
 
+react-table@^7.8.0:
+  version "7.8.0"
+  resolved "https://registry.yarnpkg.com/react-table/-/react-table-7.8.0.tgz#07858c01c1718c09f7f1aed7034fcfd7bda907d2"
+  integrity sha512-hNaz4ygkZO4bESeFfnfOft73iBUj8K5oKi1EcSHPAibEydfsX2MyU6Z8KCr3mv3C9Kqqh71U+DhZkFvibbnPbA==
+
 react-transition-group@^4.3.0:
   version "4.4.5"
   resolved "https://registry.yarnpkg.com/react-transition-group/-/react-transition-group-4.4.5.tgz#e53d4e3f3344da8521489fbef8f2581d42becdd1"


### PR DESCRIPTION
### Description:
This PR adds a list-view that can be used to render any admin page. This list view should be treated as a way to quickly render out queries for models.

### Trello Link:
https://trello.com/c/s4EpRGOo/3-aps-3-design-reusable-list-view

### How to use:
When rendering the table in your page, you need to pass it `columns` and `data` props.
`data` is usually an array of objects returned by GQL.
`columns` is a set of instructions on what to render into the table:
```
const columns = useMemo(
    () => [
      {
        Header: "Users",
        columns: [
          {
            Header: "ID",
            accessor: "id",
          },
          {
            Header: "Full Name",
            accessor: "fullName",
          },
        ],
      }
    ],
    []
  )
```

### Screenshot:
<img width="823" alt="image" src="https://user-images.githubusercontent.com/5695484/220801440-5d7b158a-2f9e-41a9-b41a-a7e1911ae421.png">
