### PR TITLE
APS 33 - Truncate text

### DIFF
--- a/frontend/src/components/Admin/Table/Table.js
+++ b/frontend/src/components/Admin/Table/Table.js
@@ -1,18 +1,20 @@
 import { useTable, useFilters, useSortBy, usePagination } from "react-table";
 import { useState } from "react";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
-import { 
+import {
   faAnglesRight,
   faAnglesLeft,
   faArrowUpAZ,
   faArrowDownZA,
-  faArrowRotateRight
+  faArrowRotateRight,
+  faSort
 } from "@fortawesome/free-solid-svg-icons";
 import { useNavigate } from "react-router-dom"
 
 const Table = ({ columns, data }) => {
   const right = <FontAwesomeIcon icon={faAnglesRight} />;
   const left = <FontAwesomeIcon icon={faAnglesLeft} />;
+  const sort = <FontAwesomeIcon icon={faSort} />
   const asc = <FontAwesomeIcon icon={faArrowUpAZ} />;
   const desc = <FontAwesomeIcon icon={faArrowDownZA} />;
   const reset = <FontAwesomeIcon icon={faArrowRotateRight} />;
@@ -165,7 +167,7 @@ const Table = ({ columns, data }) => {
         </span>
       </div>
 
-      <table className="admin-tables" {...getTableProps()}>
+      <table className="w-full admin-tables" {...getTableProps()}>
         <thead>
           {headerGroups.map((headerGroup) => (
             <tr className="admin-tables" {...headerGroup.getHeaderGroupProps()}>
@@ -176,10 +178,13 @@ const Table = ({ columns, data }) => {
                 >
                   {column.render("Header")} {" "}
                   {
-                    column.isSorted
-                      ? column.isSortedDesc
-                        ? desc
-                        : asc
+                    column.parent
+                      ?
+                      column.isSorted
+                        ? column.isSortedDesc
+                          ? desc
+                          : asc
+                        : sort
                       : ""
                   }
                 </th>
@@ -197,7 +202,7 @@ const Table = ({ columns, data }) => {
               <tr {...row.getRowProps()}>
                 {row.cells.map((cell) => {
                   return (
-                    <td className="admin-tables cursor-pointer" {...cell.getCellProps()} onClick={() => handleLink(row.values.id)}>
+                    <td className="admin-tables cursor-pointer truncate max-w-[220px]" title={cell.value} {...cell.getCellProps()} onClick={() => handleLink(row.values.id)}>
                       {cell.render("Cell")}
                     </td>
                   );

--- a/frontend/src/components/Admin/Table/Table.js
+++ b/frontend/src/components/Admin/Table/Table.js
@@ -179,8 +179,7 @@ const Table = ({ columns, data }) => {
                   {column.render("Header")} {" "}
                   {
                     column.parent
-                      ?
-                      column.isSorted
+                      ? column.isSorted
                         ? column.isSortedDesc
                           ? desc
                           : asc

--- a/frontend/src/components/Admin/Table/Table.js
+++ b/frontend/src/components/Admin/Table/Table.js
@@ -198,7 +198,7 @@ const Table = ({ columns, data }) => {
           {page.map((row) => {
             prepareRow(row);
             return (
-              <tr {...row.getRowProps()}>
+              <tr className="hover:outline hover:text-blue-500" {...row.getRowProps()}>
                 {row.cells.map((cell) => {
                   return (
                     <td className="admin-tables cursor-pointer truncate max-w-[220px]" title={cell.value} {...cell.getCellProps()} onClick={() => handleLink(row.values.id)}>

--- a/frontend/src/components/ProductForm/ProductForm.js
+++ b/frontend/src/components/ProductForm/ProductForm.js
@@ -37,7 +37,7 @@ const ProductForm = () => {
 
   return (
     <>
-      <form ref={formRef} onSubmit={handleSubmit} className="max-w-xl m-6">
+      <form ref={formRef} onSubmit={handleSubmit} className="max-w-2xl m-6">
         <h1 className="text-2xl text-center mb-3">{id ? "Edit Product" : "Add Product"}</h1>
         <label className="admin-form-label">
           Name:
@@ -66,7 +66,7 @@ const ProductForm = () => {
             defaultValue={product?.data?.data?.data?.product.description && product.data.data.data.product.description}
             type="text"
             name="description"
-            rows="3"
+            rows="15"
             required
           />
         </label>

--- a/frontend/src/pages/ProductsPage/ProductsPage.js
+++ b/frontend/src/pages/ProductsPage/ProductsPage.js
@@ -23,10 +23,6 @@ const ProductsPage = () => {
                         accessor: "price",
                     },
                     {
-                        Header: "Description",
-                        accessor: "description",
-                    },
-                    {
                         Header: "Created At",
                         accessor: "createdAt",
                     },


### PR DESCRIPTION
Overflowing text in table is truncated with an ellipsis by setting max width of each cell to 220px. Hover over cell to show entire text.

Also added Sort icon to headings and row hover effects.

<img width="821" alt="Screen Shot 2023-03-13 at 9 04 50 PM" src="https://user-images.githubusercontent.com/109117779/224871562-6ec2a6c0-0a83-4046-b2e2-8138f31934f5.png">
