### PR TITLE
Aps 42 title banner

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -4,6 +4,8 @@
   "private": true,
   "dependencies": {
     "@fortawesome/fontawesome-svg-core": "^6.3.0",
+    "@fortawesome/free-brands-svg-icons": "^6.3.0",
+    "@fortawesome/free-regular-svg-icons": "^6.3.0",
     "@fortawesome/free-solid-svg-icons": "^6.3.0",
     "@fortawesome/react-fontawesome": "^0.2.0",
     "@testing-library/jest-dom": "^5.16.5",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -18,6 +18,7 @@
     "react-country-region-selector": "^3.6.1",
     "react-dom": "^18.2.0",
     "react-hot-toast": "^2.4.0",
+    "react-icons": "^4.8.0",
     "react-loading-skeleton": "^3.2.0",
     "react-query": "^3.39.2",
     "react-query-devtools": "^2.6.3",

--- a/frontend/src/components/Header/TitleBanner/CartIcon.js
+++ b/frontend/src/components/Header/TitleBanner/CartIcon.js
@@ -1,0 +1,19 @@
+import { Link } from "react-router-dom"
+import { BiShoppingBag } from "react-icons/bi"
+
+const CartIcon = () => {
+  const bagIcon = <BiShoppingBag style={{fontSize: '1.95rem'}} />
+
+  return (
+    <Link to="/app/cart" className="relative hover:text-indigo-400 ease-in duration-150">
+      {bagIcon}
+      <span class="absolute -right-3 -top-1">
+        <div class="inline-flex items-center px-1.5 py-0.5 rounded-full text-xs font-bold bg-cyan-500 opacity-70 text-white border-2">
+          0
+        </div>
+      </span>
+    </Link>
+  )
+}
+
+export default CartIcon;

--- a/frontend/src/components/Header/TitleBanner/SearchBar.js
+++ b/frontend/src/components/Header/TitleBanner/SearchBar.js
@@ -1,0 +1,14 @@
+import { BiSearch } from "react-icons/bi"
+
+const SearchBar = () => {
+  const searchIcon = <BiSearch className="text-2xl" />
+  
+  return (
+    <div className="flex border-2 rounded-md border-gray-600 mr-2 px-1 hover:border-indigo-400 ease-in duration-150">
+      <input type="text" className="bg-transparent focus:outline-none"></input>
+      <button className="hover:text-indigo-400 ease-in duration-150">{searchIcon}</button>
+    </div>
+  )
+}
+
+export default SearchBar;

--- a/frontend/src/components/Header/TitleBanner/TitleBanner.js
+++ b/frontend/src/components/Header/TitleBanner/TitleBanner.js
@@ -47,13 +47,13 @@ const TitleBanner = () => {
         <Link to="/">Aiya Pet Studio</Link>
       </h1>
       <div className="flex text-gray-600">
-        <div className="flex border-2 rounded-md border-gray-600 mr-2 px-1">
+        <div className="flex border-2 rounded-md border-gray-600 mr-2 px-1 hover:border-indigo-400 ease-in duration-150">
           <input type="text" className="bg-transparent focus:outline-none"></input>
           <button className="hover:text-indigo-400 ease-in duration-150">{searchIcon}</button>
         </div>
         <div className="group inline-block relative mx-2 mt-1 ">
-          <button>
-            <span className="hover:text-indigo-400 ease-in duration-150">{userIcon}{dropdownIcon}</span>
+          <button className="hover:text-indigo-400 ease-in duration-150">
+            <span>{userIcon}{dropdownIcon}</span>
           </button>
           <ul className="absolute -left-8 hidden group-hover:block drop-shadow-lg">
             {user ? authenticatedOptions : unauthenticatedOptions}

--- a/frontend/src/components/Header/TitleBanner/TitleBanner.js
+++ b/frontend/src/components/Header/TitleBanner/TitleBanner.js
@@ -15,12 +15,12 @@ const TitleBanner = () => {
 
   const authenticatedOptions = (
     <>
-      <li className="rounded-t-md bg-violet-50 py-2 px-4 hover:bg-violet-100 block whitespace-nowrap">
+      <li className="rounded-t-md bg-violet-50 py-2 px-4 hover:bg-violet-100 hover:text-indigo-500 block whitespace-nowrap ease-in duration-150">
         <Link to="/app/account">
           My Account
         </Link>
       </li>
-      <li className="rounded-b-md bg-violet-50 py-2 px-4 hover:bg-violet-100 block whitespace-nowrap">
+      <li className="rounded-b-md bg-violet-50 py-2 px-4 hover:bg-violet-100 hover:text-indigo-500 block whitespace-nowrap ease-in duration-150">
         <Logout />
       </li>
     </>
@@ -28,12 +28,12 @@ const TitleBanner = () => {
 
   const unauthenticatedOptions = (
     <>
-      <li className="rounded-t-md bg-violet-50 py-2 px-4 hover:bg-violet-100 block whitespace-nowrap">
+      <li className="rounded-t-md bg-violet-50 py-2 px-4 hover:bg-violet-100 hover:text-indigo-500 block whitespace-nowrap ease-in duration-150">
         <Link to="/app/login">
           Log In
         </Link>
       </li>
-      <li className="rounded-b-md bg-violet-50 py-2 px-4 hover:bg-violet-100 block whitespace-nowrap">
+      <li className="rounded-b-md bg-violet-50 py-2 px-4 hover:bg-violet-100 hover:text-indigo-500 block whitespace-nowrap ease-in duration-150">
         <Link to="/app/login">
           Register
         </Link>
@@ -55,7 +55,7 @@ const TitleBanner = () => {
           <button>
             <span className="hover:text-indigo-400 ease-in duration-150">{userIcon}{dropdownIcon}</span>
           </button>
-          <ul className="absolute -left-8 hidden group-hover:block drop-shadow-lg ease-in duration-300">
+          <ul className="absolute -left-8 hidden group-hover:block drop-shadow-lg">
             {user ? authenticatedOptions : unauthenticatedOptions}
           </ul>
         </div>

--- a/frontend/src/components/Header/TitleBanner/TitleBanner.js
+++ b/frontend/src/components/Header/TitleBanner/TitleBanner.js
@@ -47,19 +47,19 @@ const TitleBanner = () => {
         <Link to="/">Aiya Pet Studio</Link>
       </h1>
       <div className="flex text-gray-600">
-        <div className="flex border-2 rounded-md border-gray-600 mr-2">
-          <input type="text" className="bg-transparent"></input>
-          <button className="hover:text-indigo-400">{searchIcon}</button>
+        <div className="flex border-2 rounded-md border-gray-600 mr-2 px-1">
+          <input type="text" className="bg-transparent focus:outline-none"></input>
+          <button className="hover:text-indigo-400 ease-in duration-150">{searchIcon}</button>
         </div>
         <div className="group inline-block relative mx-2 mt-1 ">
           <button>
-            <span className="hover:text-indigo-400">{userIcon}{dropdownIcon}</span>
+            <span className="hover:text-indigo-400 ease-in duration-150">{userIcon}{dropdownIcon}</span>
           </button>
-          <ul className="absolute -left-8 hidden group-hover:block drop-shadow-lg">
+          <ul className="absolute -left-8 hidden group-hover:block drop-shadow-lg ease-in duration-300">
             {user ? authenticatedOptions : unauthenticatedOptions}
           </ul>
         </div>
-        <Link to="/app/cart" className="hover:text-indigo-400">{bagIcon}</Link>
+        <Link to="/app/cart" className="hover:text-indigo-400 ease-in duration-150">{bagIcon}</Link>
       </div>
     </div>
   )

--- a/frontend/src/components/Header/TitleBanner/TitleBanner.js
+++ b/frontend/src/components/Header/TitleBanner/TitleBanner.js
@@ -2,16 +2,15 @@ import { Link } from "react-router-dom"
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { faUser } from "@fortawesome/free-regular-svg-icons"
 import { faCaretDown } from "@fortawesome/free-solid-svg-icons"
-import { BiShoppingBag, BiSearch } from "react-icons/bi"
 import { useBoundStore } from "../../../stores/useBoundStore"
 import Logout from "../../Auth/Logout"
+import SearchBar from "./SearchBar"
+import CartIcon from "./CartIcon"
 
 const TitleBanner = () => {
   const user = useBoundStore((state) => state.user)
-  const searchIcon = <BiSearch className="text-2xl" />
   const userIcon = <FontAwesomeIcon icon={faUser} className="text-2xl" />
   const dropdownIcon = <FontAwesomeIcon icon={faCaretDown} className="text-base" />
-  const bagIcon = <BiShoppingBag className="text-3xl" />
 
   const authenticatedOptions = (
     <>
@@ -47,10 +46,7 @@ const TitleBanner = () => {
         <Link to="/">Aiya Pet Studio</Link>
       </h1>
       <div className="flex text-gray-600">
-        <div className="flex border-2 rounded-md border-gray-600 mr-2 px-1 hover:border-indigo-400 ease-in duration-150">
-          <input type="text" className="bg-transparent focus:outline-none"></input>
-          <button className="hover:text-indigo-400 ease-in duration-150">{searchIcon}</button>
-        </div>
+        <SearchBar />
         <div className="group inline-block relative mx-2 mt-1 ">
           <button className="hover:text-indigo-400 ease-in duration-150">
             <span>{userIcon}{dropdownIcon}</span>
@@ -59,7 +55,7 @@ const TitleBanner = () => {
             {user ? authenticatedOptions : unauthenticatedOptions}
           </ul>
         </div>
-        <Link to="/app/cart" className="hover:text-indigo-400 ease-in duration-150">{bagIcon}</Link>
+        <CartIcon />
       </div>
     </div>
   )

--- a/frontend/src/components/Header/TitleBanner/TitleBanner.js
+++ b/frontend/src/components/Header/TitleBanner/TitleBanner.js
@@ -1,0 +1,68 @@
+import { Link } from "react-router-dom"
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
+import { faUser } from "@fortawesome/free-regular-svg-icons"
+import { faCaretDown } from "@fortawesome/free-solid-svg-icons"
+import { BiShoppingBag, BiSearch } from "react-icons/bi"
+import { useBoundStore } from "../../../stores/useBoundStore"
+import Logout from "../../Auth/Logout"
+
+const TitleBanner = () => {
+  const user = useBoundStore((state) => state.user)
+  const searchIcon = <BiSearch className="text-2xl" />
+  const userIcon = <FontAwesomeIcon icon={faUser} className="text-2xl" />
+  const dropdownIcon = <FontAwesomeIcon icon={faCaretDown} className="text-base" />
+  const bagIcon = <BiShoppingBag className="text-3xl" />
+
+  const authenticatedOptions = (
+    <>
+      <li className="rounded-t-md bg-violet-50 py-2 px-4 hover:bg-violet-100 block whitespace-nowrap">
+        <Link to="/app/account">
+          My Account
+        </Link>
+      </li>
+      <li className="rounded-b-md bg-violet-50 py-2 px-4 hover:bg-violet-100 block whitespace-nowrap">
+        <Logout />
+      </li>
+    </>
+  )
+
+  const unauthenticatedOptions = (
+    <>
+      <li className="rounded-t-md bg-violet-50 py-2 px-4 hover:bg-violet-100 block whitespace-nowrap">
+        <Link to="/app/login">
+          Log In
+        </Link>
+      </li>
+      <li className="rounded-b-md bg-violet-50 py-2 px-4 hover:bg-violet-100 block whitespace-nowrap">
+        <Link to="/app/login">
+          Register
+        </Link>
+      </li>
+    </>
+  )
+
+  return (
+    <div className="w-full h-20 flex justify-between items-center bg-gradient-to-r from-indigo-400 to-pink-200 px-6">
+      <h1 className="text-white text-3xl">
+        <Link to="/">Aiya Pet Studio</Link>
+      </h1>
+      <div className="flex text-gray-600">
+        <div className="flex border-2 rounded-md border-gray-600 mr-2">
+          <input type="text" className="bg-transparent"></input>
+          <button className="hover:text-indigo-400">{searchIcon}</button>
+        </div>
+        <div className="group inline-block relative mx-2 mt-1 ">
+          <button>
+            <span className="hover:text-indigo-400">{userIcon}{dropdownIcon}</span>
+          </button>
+          <ul className="absolute -left-8 hidden group-hover:block drop-shadow-lg">
+            {user ? authenticatedOptions : unauthenticatedOptions}
+          </ul>
+        </div>
+        <Link to="/app/cart" className="hover:text-indigo-400">{bagIcon}</Link>
+      </div>
+    </div>
+  )
+}
+
+export default TitleBanner

--- a/frontend/src/routes/UserRoutes.js
+++ b/frontend/src/routes/UserRoutes.js
@@ -7,11 +7,13 @@ import ProtectedRoute from "./ProtectedRoute"
 import ResetPassword from "../components/Auth/ResetPassword"
 import Confirmation from "../components/Auth/Confirmation"
 import { useBoundStore } from "../stores/useBoundStore"
+import TitleBanner from "../components/Header/TitleBanner/TitleBanner"
 
 function UserRoutes() {
   const user = useBoundStore((state) => state.user)
   return (
     <>
+      <TitleBanner />
       <Navbar />
       <Routes>
         <Route path="/app" element={<Dashboard />} />
@@ -38,6 +40,12 @@ function UserRoutes() {
               <Confirmation />
             </ProtectedRoute>
           }
+        />
+        <Route
+          path="/app/cart"
+          // element={
+          //   <Cart />
+          // }
         />
       </Routes>
     </>

--- a/frontend/src/routes/UserRoutes.js
+++ b/frontend/src/routes/UserRoutes.js
@@ -43,9 +43,6 @@ function UserRoutes() {
         />
         <Route
           path="/app/cart"
-          // element={
-          //   <Cart />
-          // }
         />
       </Routes>
     </>

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -7737,6 +7737,11 @@ react-hot-toast@^2.4.0:
   dependencies:
     goober "^2.1.10"
 
+react-icons@^4.8.0:
+  version "4.8.0"
+  resolved "https://registry.yarnpkg.com/react-icons/-/react-icons-4.8.0.tgz#621e900caa23b912f737e41be57f27f6b2bff445"
+  integrity sha512-N6+kOLcihDiAnj5Czu637waJqSnwlMNROzVZMhfX68V/9bu9qHaMIJC4UdozWoOk57gahFCNHwVvWzm0MTzRjg==
+
 react-is@^16.13.1, react-is@^16.7.0:
   version "16.13.1"
   resolved "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz"

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -1314,6 +1314,20 @@
   dependencies:
     "@fortawesome/fontawesome-common-types" "6.3.0"
 
+"@fortawesome/free-brands-svg-icons@^6.3.0":
+  version "6.3.0"
+  resolved "https://registry.yarnpkg.com/@fortawesome/free-brands-svg-icons/-/free-brands-svg-icons-6.3.0.tgz#436e5fcba4f4f0902edcceaec5c4ff887ba7328f"
+  integrity sha512-xI0c+a8xnKItAXCN8rZgCNCJQiVAd2Y7p9e2ND6zN3J3ekneu96qrePieJ7yA7073C1JxxoM3vH1RU7rYsaj8w==
+  dependencies:
+    "@fortawesome/fontawesome-common-types" "6.3.0"
+
+"@fortawesome/free-regular-svg-icons@^6.3.0":
+  version "6.3.0"
+  resolved "https://registry.yarnpkg.com/@fortawesome/free-regular-svg-icons/-/free-regular-svg-icons-6.3.0.tgz#286f87f777e6c96af59151e86647c81083029ee2"
+  integrity sha512-cZnwiVHZ51SVzWHOaNCIA+u9wevZjCuAGSvSYpNlm6A4H4Vhwh8481Bf/5rwheIC3fFKlgXxLKaw8Xeroz8Ntg==
+  dependencies:
+    "@fortawesome/fontawesome-common-types" "6.3.0"
+
 "@fortawesome/free-solid-svg-icons@^6.3.0":
   version "6.3.0"
   resolved "https://registry.yarnpkg.com/@fortawesome/free-solid-svg-icons/-/free-solid-svg-icons-6.3.0.tgz#d3bd33ae18bb15fdfc3ca136e2fea05f32768a65"


### PR DESCRIPTION
The title banner component currently consists of a placeholder shop logo, a non-functional search bar, a user account button, and a shopping bag link.

On hover, user account button displays either authenticated or unauthenticated options based on account status.
<img width="1434" alt="Screen Shot 2023-03-20 at 5 44 31 PM" src="https://user-images.githubusercontent.com/109117779/226684250-846d3918-72cf-46a9-a1ad-b815f0e5d660.png">

<img width="1423" alt="Screen Shot 2023-03-21 at 12 54 24 PM" src="https://user-images.githubusercontent.com/109117779/226684286-4ac98345-e221-42d6-bee7-e3e4f5e27628.png">

Adds a visual badge for notification numbers.
<img width="1427" alt="Screen Shot 2023-03-21 at 4 37 51 PM" src="https://user-images.githubusercontent.com/109117779/226735037-ebfea163-6558-4726-866f-0aa49b399a18.png">


Remember to yarn install to update dependencies.