### PR TITLE
[APS-36] Adds potential user migration and references with user model

### DIFF
--- a/app/models/potential_user.rb
+++ b/app/models/potential_user.rb
@@ -1,0 +1,23 @@
+# == Schema Information
+#
+# Table name: potential_users
+#
+#  id           :bigint           not null, primary key
+#  email        :string           not null
+#  address1     :string
+#  address2     :string
+#  country      :string
+#  city         :string
+#  state        :string
+#  zipcode      :string
+#  phone_number :string
+#  first_name   :string
+#  middle_name  :string
+#  last_name    :string
+#  created_at   :datetime         not null
+#  updated_at   :datetime         not null
+#  user_id      :bigint           not null
+#
+class PotentialUser < ApplicationRecord
+  belongs_to :user, optional: true
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -40,6 +40,8 @@ class User < ApplicationRecord
          :recoverable, :rememberable, :validatable,
          :confirmable, :trackable
   enum :gender, [:woman, :man, :transgender, :non_binary, :unknown]
+
+  has_one :potential_user
   
   def full_name
     [first_name, middle_name, last_name].compact.join(' ')

--- a/db/migrate/20230323184719_create_potential_users.rb
+++ b/db/migrate/20230323184719_create_potential_users.rb
@@ -1,0 +1,20 @@
+class CreatePotentialUsers < ActiveRecord::Migration[7.0]
+  def change
+    create_table :potential_users do |t|
+      t.string :email, null: false
+      t.string :address1
+      t.string :address2
+      t.string :country
+      t.string :city
+      t.string :state
+      t.string :zipcode
+      t.string :phone_number
+      t.string :first_name
+      t.string :middle_name
+      t.string :last_name
+
+      t.timestamps
+    end
+    add_index :potential_users, :email, unique: true
+  end
+end

--- a/db/migrate/20230323191541_add_user_id_to_potential_users.rb
+++ b/db/migrate/20230323191541_add_user_id_to_potential_users.rb
@@ -1,0 +1,5 @@
+class AddUserIdToPotentialUsers < ActiveRecord::Migration[7.0]
+  def change
+    add_reference :potential_users, :user, null: false, foreign_key: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_03_19_005916) do
+ActiveRecord::Schema[7.0].define(version: 2023_03_23_191541) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -27,6 +27,25 @@ ActiveRecord::Schema[7.0].define(version: 2023_03_19_005916) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["product_id"], name: "index_featured_products_on_product_id"
+  end
+
+  create_table "potential_users", force: :cascade do |t|
+    t.string "email", null: false
+    t.string "address1"
+    t.string "address2"
+    t.string "country"
+    t.string "city"
+    t.string "state"
+    t.string "zipcode"
+    t.string "phone_number"
+    t.string "first_name"
+    t.string "middle_name"
+    t.string "last_name"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.bigint "user_id", null: false
+    t.index ["email"], name: "index_potential_users_on_email", unique: true
+    t.index ["user_id"], name: "index_potential_users_on_user_id"
   end
 
   create_table "products", force: :cascade do |t|
@@ -91,4 +110,5 @@ ActiveRecord::Schema[7.0].define(version: 2023_03_19_005916) do
   end
 
   add_foreign_key "featured_products", "products"
+  add_foreign_key "potential_users", "users"
 end


### PR DESCRIPTION
### What does this do:
This PR will create the PotentialUser model. This model is used to track users who may have either bought something but did not register, or a user that needs to be populated off of a review. We will eventually grab Etsy Reviews which will be associated with a user. Instead of creating that user association, we will instead create a PotentialUser<-> Review association.