### PR TITLE
Aps 8 reviews and etsy reviews

### DIFF
--- a/app/models/etsy.rb
+++ b/app/models/etsy.rb
@@ -1,0 +1,5 @@
+module Etsy
+  def self.table_name_prefix
+    "etsy_"
+  end
+end

--- a/app/models/etsy/etsy_review.rb
+++ b/app/models/etsy/etsy_review.rb
@@ -1,0 +1,26 @@
+# == Schema Information
+#
+# Table name: etsy_etsy_reviews
+#
+#  id                  :bigint           not null, primary key
+#  shop_id             :integer
+#  listing_id          :integer
+#  transaction_id      :integer
+#  buyer_user_id       :integer
+#  rating              :integer
+#  review              :string           default("")
+#  language            :string
+#  image_url_fullxfull :string
+#  created_timestamp   :integer
+#  updated_timestamp   :integer
+#  buyer_email         :string           default("")
+#  review_id           :bigint           not null
+#  potential_user_id   :bigint
+#  created_at          :datetime         not null
+#  updated_at          :datetime         not null
+#
+class Etsy::EtsyReview < ApplicationRecord
+  belongs_to :potential_user, optional: true
+
+  belongs_to :review
+end

--- a/app/models/potential_user.rb
+++ b/app/models/potential_user.rb
@@ -16,7 +16,7 @@
 #  last_name    :string
 #  created_at   :datetime         not null
 #  updated_at   :datetime         not null
-#  user_id      :bigint           not null
+#  user_id      :bigint
 #
 class PotentialUser < ApplicationRecord
   belongs_to :user, optional: true

--- a/app/models/potential_user.rb
+++ b/app/models/potential_user.rb
@@ -20,4 +20,5 @@
 #
 class PotentialUser < ApplicationRecord
   belongs_to :user, optional: true
+  has_many :etsy_reviews, class_name: 'Etsy::EtsyReview', dependent: :nullify
 end

--- a/app/models/product.rb
+++ b/app/models/product.rb
@@ -13,4 +13,5 @@
 #
 class Product < ApplicationRecord
     has_paper_trail
+    has_many :reviews, dependent: :destroy
 end

--- a/app/models/review.rb
+++ b/app/models/review.rb
@@ -1,0 +1,19 @@
+# == Schema Information
+#
+# Table name: reviews
+#
+#  id         :bigint           not null, primary key
+#  rating     :integer
+#  review     :text
+#  language   :string
+#  image      :string
+#  user_id    :bigint           not null
+#  product_id :bigint           not null
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#
+class Review < ApplicationRecord
+  belongs_to :user, optional: true
+  belongs_to :product
+  has_one :etsy_review, class_name: 'Etsy::EtsyReview', dependent: :nullify
+end

--- a/app/models/review.rb
+++ b/app/models/review.rb
@@ -7,7 +7,7 @@
 #  review     :text
 #  language   :string
 #  image      :string
-#  user_id    :bigint           not null
+#  user_id    :bigint
 #  product_id :bigint           not null
 #  created_at :datetime         not null
 #  updated_at :datetime         not null

--- a/app/models/review.rb
+++ b/app/models/review.rb
@@ -16,4 +16,11 @@ class Review < ApplicationRecord
   belongs_to :user, optional: true
   belongs_to :product
   has_one :etsy_review, class_name: 'Etsy::EtsyReview', dependent: :nullify
+
+  def reviewer
+    return user.email if user.present?
+    return etsy_review.buyer_email if etsy_review.present? && etsy_review.buyer_email.present?
+
+    "anonymous"
+  end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -42,6 +42,7 @@ class User < ApplicationRecord
   enum :gender, [:woman, :man, :transgender, :non_binary, :unknown]
 
   has_one :potential_user
+  has_many :reviews, dependent: :destroy
   
   def full_name
     [first_name, middle_name, last_name].compact.join(' ')

--- a/db/migrate/20230325190211_create_reviews.rb
+++ b/db/migrate/20230325190211_create_reviews.rb
@@ -1,0 +1,14 @@
+class CreateReviews < ActiveRecord::Migration[7.0]
+  def change
+    create_table :reviews do |t|
+      t.integer :rating
+      t.text :review
+      t.string :language
+      t.string :image
+      t.references :user, null: false, foreign_key: true
+      t.references :product, null: false, foreign_key: true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20230325190211_create_reviews.rb
+++ b/db/migrate/20230325190211_create_reviews.rb
@@ -5,7 +5,7 @@ class CreateReviews < ActiveRecord::Migration[7.0]
       t.text :review
       t.string :language
       t.string :image
-      t.references :user, null: false, foreign_key: true
+      t.references :user, null: true, foreign_key: true
       t.references :product, null: false, foreign_key: true
 
       t.timestamps

--- a/db/migrate/20230325191157_create_etsy_etsy_reviews.rb
+++ b/db/migrate/20230325191157_create_etsy_etsy_reviews.rb
@@ -1,0 +1,21 @@
+class CreateEtsyEtsyReviews < ActiveRecord::Migration[7.0]
+  def change
+    create_table :etsy_etsy_reviews do |t|
+      t.integer :shop_id
+      t.integer :listing_id
+      t.integer :transaction_id
+      t.integer :buyer_user_id, null: true
+      t.integer :rating
+      t.string :review, default: ""
+      t.string :language
+      t.string :image_url_fullxfull, null: true
+      t.integer :created_timestamp
+      t.integer :updated_timestamp
+      t.string :buyer_email, default: ""
+      t.references :review, null: false, foreign_key: true
+      t.references :potential_user, foreign_key: true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20230325200401_change_user_id_to_nullable_in_potential_users.rb
+++ b/db/migrate/20230325200401_change_user_id_to_nullable_in_potential_users.rb
@@ -1,0 +1,5 @@
+class ChangeUserIdToNullableInPotentialUsers < ActiveRecord::Migration[7.0]
+  def change
+    change_column_null :potential_users, :user_id, true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -83,7 +83,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_03_25_191157) do
     t.text "review"
     t.string "language"
     t.string "image"
-    t.bigint "user_id", null: false
+    t.bigint "user_id"
     t.bigint "product_id", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_03_25_191157) do
+ActiveRecord::Schema[7.0].define(version: 2023_03_25_200401) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -63,7 +63,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_03_25_191157) do
     t.string "last_name"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.bigint "user_id", null: false
+    t.bigint "user_id"
     t.index ["email"], name: "index_potential_users_on_email", unique: true
     t.index ["user_id"], name: "index_potential_users_on_user_id"
   end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_03_23_191541) do
+ActiveRecord::Schema[7.0].define(version: 2023_03_25_191157) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -20,6 +20,26 @@ ActiveRecord::Schema[7.0].define(version: 2023_03_23_191541) do
     t.string "link_to", default: ""
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+  end
+
+  create_table "etsy_etsy_reviews", force: :cascade do |t|
+    t.integer "shop_id"
+    t.integer "listing_id"
+    t.integer "transaction_id"
+    t.integer "buyer_user_id"
+    t.integer "rating"
+    t.string "review", default: ""
+    t.string "language"
+    t.string "image_url_fullxfull"
+    t.integer "created_timestamp"
+    t.integer "updated_timestamp"
+    t.string "buyer_email", default: ""
+    t.bigint "review_id", null: false
+    t.bigint "potential_user_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["potential_user_id"], name: "index_etsy_etsy_reviews_on_potential_user_id"
+    t.index ["review_id"], name: "index_etsy_etsy_reviews_on_review_id"
   end
 
   create_table "featured_products", force: :cascade do |t|
@@ -56,6 +76,19 @@ ActiveRecord::Schema[7.0].define(version: 2023_03_23_191541) do
     t.datetime "updated_at", null: false
     t.string "etsy_listing_id"
     t.integer "quantity"
+  end
+
+  create_table "reviews", force: :cascade do |t|
+    t.integer "rating"
+    t.text "review"
+    t.string "language"
+    t.string "image"
+    t.bigint "user_id", null: false
+    t.bigint "product_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["product_id"], name: "index_reviews_on_product_id"
+    t.index ["user_id"], name: "index_reviews_on_user_id"
   end
 
   create_table "tags", force: :cascade do |t|
@@ -109,6 +142,10 @@ ActiveRecord::Schema[7.0].define(version: 2023_03_23_191541) do
     t.index ["item_type", "item_id"], name: "index_versions_on_item_type_and_item_id"
   end
 
+  add_foreign_key "etsy_etsy_reviews", "potential_users"
+  add_foreign_key "etsy_etsy_reviews", "reviews"
   add_foreign_key "featured_products", "products"
   add_foreign_key "potential_users", "users"
+  add_foreign_key "reviews", "products"
+  add_foreign_key "reviews", "users"
 end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -36,7 +36,7 @@ def create_user(**args)
     }
   
     User.create(defaults.merge(args))
-  end
+end
 
 def create_product
     Product.create(
@@ -47,13 +47,13 @@ def create_product
 end
 
  # Generating Admin user
- create_user(
+create_user(
     email: 'admin@admin.com',
     admin: true,
     password: '123123',
     password_confirmation: '123123',
     confirmed_at: Time.now
- )
+)
     
 # Generating Users with no associations
 10.times do

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -17,23 +17,28 @@ puts "Seeding..."
 # Product.destroy_all
 # Tag.destroy_all
 
-20.times do
-    User.create(
-        first_name: Faker::Name.first_name,
-        middle_name: Faker::Name.middle_name,
-        last_name: Faker::Name.last_name,
-        gender: Faker::Number.between(from: 0, to: 4),
-        address1: Faker::Address.street_address,
-        state: Faker::Address.state,
-        country: "United States",
-        zipcode: Faker::Address.zip,
-        phone_number: Faker::PhoneNumber.cell_phone,
-        email: Faker::Internet.unique.email,
-        password: "somepassword"
-    )
-end
+def create_user(**args)
+    defaults = {
+      first_name: Faker::Name.first_name,
+      middle_name: Faker::Name.middle_name,
+      last_name: Faker::Name.last_name,
+      gender: Faker::Number.between(from: 0, to: 4),
+      address1: Faker::Address.street_address,
+      state: Faker::Address.state,
+      country: "United States",
+      zipcode: Faker::Address.zip,
+      phone_number: Faker::PhoneNumber.cell_phone,
+      email: Faker::Internet.unique.email,
+      password: "somepassword",
+      password_confirmation: "somepassword",
+      admin: false,
+      confirmed_at: nil
+    }
+  
+    User.create(defaults.merge(args))
+  end
 
-20.times do
+def create_product
     Product.create(
         name: Faker::Commerce.product_name,
         price: Faker::Number.between(from: 1, to: 100),
@@ -41,6 +46,26 @@ end
     )
 end
 
+ # Generating Admin user
+ create_user(
+    email: 'admin@admin.com',
+    admin: true,
+    password: '123123',
+    password_confirmation: '123123',
+    confirmed_at: Time.now
+ )
+    
+# Generating Users with no associations
+10.times do
+    create_user
+end
+
+# Generating Products with no associations
+15.times do
+    create_product
+end
+
+# Generating Tags with no associations
 5.times do
     Tag.create(name: Faker::Color.unique.color_name)
     Tag.create(name: Faker::Commerce.unique.material)
@@ -48,8 +73,33 @@ end
     Tag.create(name: Faker::Commerce.unique.department(max: 1))
 end
 
+# Generating FeaturedProduct with Products associated
 4.times do
-    FeaturedProduct.create(product_id: nil)
+    product = create_product
+    FeaturedProduct.create(product_id: product.id)
+end
+
+# Generating Reviews with Products associated
+5.times do
+    product = create_product
+    user = create_user
+    potential_user = PotentialUser.create(email: user.email)
+    review = Review.create(
+        user_id: user.id,
+        product_id: product.id,
+        rating: Faker::Number.between(from: 1, to: 5),
+        review: Faker::Lorem.paragraph(random_sentences_to_add: 1)
+    )
+    Etsy::EtsyReview.create(
+        shop_id: 1,
+        listing_id: 1,
+        transaction_id: 1,
+        buyer_user_id: 1,
+        rating: review.rating,
+        buyer_email: user.email,
+        review_id: review.id,
+        potential_user_id: potential_user.id
+    )
 end
 
 puts "Seeding done."


### PR DESCRIPTION
### What does this do?
This PR adds 2 new models and fixes up several related models.
We have a new namespace called "Etsy". This means that databases under the Etsy umbrella ( a 1:1 replica of Etsy data to the best of our ability) will be follow the pattern of Etsy::MODELNAME.

- Etsy::EtsyReview was created
- Review was created
- Adds several associations between Review, EtsyReview, Product, User and PotentialUser.
- Adds new seed data

The layman's interpretation of the relationship between the 5 models:

- A User can have many Reviews.
- A Review can optionally belong to a user
- A Review must belong to a Product.
- A Review can optionally has a EtsyReview.
- A Review MUST belong to either a User or an EtsyReview (done through validation before_create)
- An EtsyReview can MUST have a Review.
- An EtsyReview can optionally belong to a PotentialUser

###  IMPORTANT:
You are highly encouraged to drop the database when merging main with these changes. It will be necessary to run the seed data once this is merged and in order to avoid errors in running the seed, please run the following command in the console after `git pull` on main:
```
rake db:drop db:create db:migrate db:seed
```
This will drop, migrate and seed the data all in one shot for you.
An Admin account will be created for you to test things with
```
username: admin@admin.com
password: 123123
```