### PR TITLE
[Aps 59] add backend search query

### DIFF
--- a/app/graphql/queries/search_products.rb
+++ b/app/graphql/queries/search_products.rb
@@ -1,0 +1,14 @@
+module Queries
+  class SearchProducts < BaseQuery
+    type [Types::ProductType], null: false
+
+    description "Search for products by name or tag"
+    argument :search_term, String, required: true
+
+    def resolve(search_term:)
+      Product.left_outer_joins(:tags).where("products.name ILIKE ? OR tags.name ILIKE ?", "%#{search_term}%", "%#{search_term}%").distinct
+    rescue
+      raise GraphQL::ExecutionError.new "Unable to find any products"
+    end
+  end
+end

--- a/app/graphql/types/product_type.rb
+++ b/app/graphql/types/product_type.rb
@@ -8,5 +8,8 @@ module Types
     field :price, Integer
     field :created_at, GraphQL::Types::ISO8601DateTime, null: false
     field :updated_at, GraphQL::Types::ISO8601DateTime, null: false
+    field :etsy_listing_id, String
+    field :quantity, Integer
+    field :tags, [Types::TagType], null: true
   end
 end

--- a/app/graphql/types/query_type.rb
+++ b/app/graphql/types/query_type.rb
@@ -9,5 +9,6 @@ module Types
     field :featured_products, resolver: Queries::AllFeaturedProducts
     field :featured_product, resolver: Queries::OneFeaturedProduct
     field :reviews_for_homepage, resolver: Queries::ReviewsForHomepage
+    field :search_products, resolver: Queries::SearchProducts
   end
 end

--- a/app/graphql/types/tag_type.rb
+++ b/app/graphql/types/tag_type.rb
@@ -6,5 +6,6 @@ module Types
     field :name, String
     field :created_at, GraphQL::Types::ISO8601DateTime, null: false
     field :updated_at, GraphQL::Types::ISO8601DateTime, null: false
+    field :products, [Types::ProductType], null: true
   end
 end


### PR DESCRIPTION
### What does this do?
Add the associated fields for Tags and Products. Calls upon these associated fields using the SearchProducts query which takes a string and returns all products that have the string within it's name or contains a tag with the string.

### Screenshots:
![Screenshot 2023-04-05 231114](https://user-images.githubusercontent.com/5695484/230263414-84fdfe2c-7e0f-41c5-9311-caa47e59726b.png)
The word "go" can be found in the first Product's associated tags ("GOld")
The word "go" can also be found in the second Product's name ("ErGOnomic Iron Hat")