### PR TITLE
adds search bar to search page

### DIFF
--- a/frontend/src/components/Header/TitleBanner/SearchBar.js
+++ b/frontend/src/components/Header/TitleBanner/SearchBar.js
@@ -16,8 +16,8 @@ const SearchBar = () => {
   }
 
   return (
-    <form ref={formRef} onSubmit={handleSearch} className="flex justify-between border-2 rounded-md border-gray-600 mx-2 px-1 hover:text-indigo-400/80 hover:border-indigo-400/80 ease-in duration-150">
-      <input type="text" name="searchTerm" className="bg-transparent focus:outline-none w-full" required></input>
+    <form ref={formRef} onSubmit={handleSearch} className="flex justify-between border-2 rounded h-9 shadow border-gray-600 mx-2 px-1 hover:text-indigo-400/80 hover:border-indigo-400/80 ease-in duration-150">
+      <input type="text" name="searchTerm" className="bg-transparent focus:outline-none w-full text-gray-700" required></input>
       <button type="submit">{searchIcon}</button>
     </form>
   )

--- a/frontend/src/pages/Client/SearchPage/SearchPage.js
+++ b/frontend/src/pages/Client/SearchPage/SearchPage.js
@@ -4,6 +4,7 @@ import SearchSection from "../../../components/Client/SearchSection/SearchSectio
 import Dropdown from "../../../components/Client/Dropdown/Dropdown"
 import { useState, useEffect, useMemo } from "react"
 import ProductCardSkeleton from "../../../components/Client/Skeletons/ProductCardSkeleton/ProductCardSkeleton"
+import SearchBar from "../../../components/Header/TitleBanner/SearchBar"
 
 const SearchPage = () => {
   const searchParams = new URLSearchParams(useLocation().search)
@@ -23,11 +24,11 @@ const SearchPage = () => {
       if (status === 'error') return <h1>{error.message || "Something went wrong!"}</h1>
       if (status === 'loading') {
         return Array(16)
-        .fill()
-        .map((_, i) => (
-          <ProductCardSkeleton key={i} />
+          .fill()
+          .map((_, i) => (
+            <ProductCardSkeleton key={i} />
           )
-        )
+          )
       }
       return <SearchSection foundProducts={foundProducts} />
     }, [status]
@@ -65,17 +66,19 @@ const SearchPage = () => {
   }
 
   return (
-    <div className="flex flex-col">
-      <div className="align-center-max">
-        <div className="ml-auto">
+    <div>
+      <div className="align-center-max flex-nowrap flex-col-reverse justify-between items-start sm:flex-row sm:items-center">
+        <p className="basis-2/6 text-start ml-10 sm:ml-3">Results for <span className="text-cyan-500 ml-1">"{searchTerm}"</span></p>
+        <div className="align-center-max flex-nowrap justify-evenly sm:justify-end items-center">
+          <SearchBar />
           <Dropdown prefix={"Sort"} sortOptions={sortOptions} handleOptions={handleOptions} defaultValue={sortQuery} />
         </div>
       </div>
-      <div className="align-center-max">
+      <div className="align-center-max mt-4">
         {content}
       </div>
     </div>
   )
 }
- 
+
 export default SearchPage


### PR DESCRIPTION
This adds the search bar to the search page beside the sort-dropdown. 

Instead of having the search term persist in the input field after submit, I have added a 'Results for "{searchTerm}"' . This means user doesn't need to double-click to highlight/clear search bar prior to entering a new search term while still knows what search is currently being displayed. 

Desktop:
![Screen Shot 2023-04-20 at 5 39 27 PM](https://user-images.githubusercontent.com/109117779/233493498-b3700361-c31a-40d1-949f-0cb21c28ee5a.png)

Mobile:
![Screen Shot 2023-04-20 at 5 39 12 PM](https://user-images.githubusercontent.com/109117779/233493507-fd76849a-6fb8-4136-8d1e-4ff2b2206051.png)
