### PR TITLE
[APS-71] Adds script to run all setups

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "aiya-pet-studio",
   "version": "1.0.0",
   "scripts": {
-    "start": "node start.js"
+    "start": "node start.js",
+    "setup": "node setup.js"
   }
 }

--- a/setup.js
+++ b/setup.js
@@ -1,0 +1,24 @@
+const { spawn } = require('child_process')
+
+const backendInstall = spawn('bundle', ['install'], { cwd: 'backend', stdio: 'inherit' })
+backendInstall.on('exit', (code) => {
+  if (code === 0) {
+    const dbMigrate = spawn('bin/rails', ['db:migrate'], { cwd: 'backend', stdio: 'inherit' })
+    dbMigrate.on('exit', (code) => {
+      if (code === 0) {
+        const frontendInstall = spawn('yarn', ['install'], { cwd: 'frontend', stdio: 'inherit' })
+        frontendInstall.on('exit', (code) => {
+          if (code === 0) {
+            console.log('Setup completed successfully!')
+          } else {
+            console.error('Failed to run "yarn install"')
+          }
+        })
+      } else {
+        console.error('Failed to run "bin/rails db:migrate"')
+      }
+    })
+  } else {
+    console.error('Failed to run "bundle install"')
+  }
+})


### PR DESCRIPTION
This MR adds a script to run from the root directory similar to the `start` command.
This script runs
- bin/rails db:migrate
- bundle install
- yarn install

To run the script from the root directory, type `npm run setup`