### PR TITLE
Aps 69 footer margin

### DIFF
--- a/frontend/src/components/Client/Social/Instagram.js
+++ b/frontend/src/components/Client/Social/Instagram.js
@@ -1,9 +1,8 @@
 import { BsInstagram } from "react-icons/bs"
-import { Link } from "react-router-dom";
 
 const Instagram = () => {
   return (
-    <Link className="flex mb-2 mt-4" to="https://www.instagram.com/aiyapetstudio/">Follow us <BsInstagram className="ml-2 text-xl" /></Link>
+    <a className="flex mb-2 mt-4" href="https://www.instagram.com/aiyapetstudio/" target="_blank">Follow us <BsInstagram className="ml-2 text-xl" /></a>
   );
 }
  

--- a/frontend/src/components/Client/Social/Instagram.js
+++ b/frontend/src/components/Client/Social/Instagram.js
@@ -3,7 +3,7 @@ import { Link } from "react-router-dom";
 
 const Instagram = () => {
   return (
-    <Link className="flex mb-2 mt-4" to="https://www.instagram.com/aiyapetstudio/">Follow us on <BsInstagram className="ml-2 text-xl" /></Link>
+    <Link className="flex mb-2 mt-4" to="https://www.instagram.com/aiyapetstudio/">Follow us <BsInstagram className="ml-2 text-xl" /></Link>
   );
 }
  

--- a/frontend/src/components/Footer/Footer.js
+++ b/frontend/src/components/Footer/Footer.js
@@ -3,32 +3,35 @@ import Instagram from "../Client/Social/Instagram"
 
 const Footer = () => {
   return (
-    <div className="flex flex-col mt-auto bg-indigo-400 text-white">
-      <div className="mx-auto w-full max-w-6xl">
-        <div className="flex flex-col md:flex-row md:justify-between md:mr-16">
-          <div className="flex justify-around pt-4 md:w-96 md:items-center">
-            <div className="flex flex-col">
-              <h5 className="text-xl mb-2">ABOUT</h5>
-              <LinkWrapper to="#" title="Reviews" />
-              <LinkWrapper to="#" title="Our Story" />
-              <LinkWrapper to="#" title="Careers" />
+    <>
+      <div className='bg-white h-5'></div>
+      <div className=" mt-auto bg-indigo-400 text-white">
+        <div className="mx-auto w-full max-w-6xl">
+          <div className="flex flex-col md:flex-row md:justify-around">
+            <div className="flex justify-evenly mt-4 md:w-96 md:items-center md:justify-around">
+              <div className="flex flex-col">
+                <h5 className="text-xl mb-2">ABOUT</h5>
+                <LinkWrapper to="#" title="Reviews" />
+                <LinkWrapper to="#" title="Our Story" />
+                <LinkWrapper to="#" title="Careers" />
+              </div>
+              <div className="flex flex-col">
+                <h5 className="text-xl mb-2">SUPPORT</h5>
+                <LinkWrapper to="#" title="Contact Us" />
+                <LinkWrapper to="#" title="Shipping" />
+                <LinkWrapper to="#" title="Returns" />
+              </div>
             </div>
-            <div className="flex flex-col">
-              <h5 className="text-xl mb-2">SUPPORT</h5>
-              <LinkWrapper to="#" title="Contact Us" />
-              <LinkWrapper to="#" title="Shipping" />
-              <LinkWrapper to="#" title="Returns" />
+            <div className="mx-auto md:flex md:items-center md:justify-center md:basis-1/6">
+              <Instagram />
             </div>
-          </div>
-          <div className="flex flex-col items-center">
-            <Instagram />
             <img src="https://i.etsystatic.com/24762991/r/il/9f62c0/3430721950/il_794xN.3430721950_4c7c.jpg"
-            className="w-80 h-48 object-cover mx-auto rounded-md" />
+              className="mt-5 mx-auto w-80 h-48 object-cover rounded-md" />
           </div>
         </div>
+        <div className="mt-2 p-2 text-sm text-center">Copyright &copy; 2023, Aiya Pet Studio</div>
       </div>
-      <div className="mt-2 p-2 text-sm mx-auto">Copyright &copy; 2023, Aiya Pet Studio</div>
-    </div>
+    </>
   )
 }
 

--- a/frontend/src/components/Footer/Footer.js
+++ b/frontend/src/components/Footer/Footer.js
@@ -4,7 +4,7 @@ import Instagram from "../Client/Social/Instagram"
 const Footer = () => {
   return (
     <>
-      <div className='bg-white h-5'></div>
+      <div className='bg-transparent h-8'></div>
       <div className=" mt-auto bg-indigo-400 text-white">
         <div className="mx-auto w-full max-w-6xl">
           <div className="flex flex-col md:flex-row md:justify-around">


### PR DESCRIPTION
Adds margin above footer using a transparent div with fixed height. Adding mt-8 directly to the parent div in the footer breaks the page layout, causing the footer to no longer stick to the bottom of page or viewport (i.e. on login page).
If you know a better way to do this, please feel free. 

This also fixes the external Instagram link.
 